### PR TITLE
Do not remove snippet areas that are not managed by the bundle

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -61,6 +61,7 @@ services:
     PERSPEQTIVE\SuluSnippetManagerBundle\Serializer\SnippetAreaNormalizer:
         arguments:
             $securityChecker: '@sulu_security.security_checker'
+            $configuredSnippetTypesProvider: '@perspeqtive_sulu_snippet_manager.configuration.configured_snippet_types_provider'
         calls:
             - [setNormalizer, ['@serializer']]
         tags:

--- a/src/Serializer/SnippetAreaNormalizer.php
+++ b/src/Serializer/SnippetAreaNormalizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PERSPEQTIVE\SuluSnippetManagerBundle\Serializer;
 
 use ArrayObject;
+use PERSPEQTIVE\SuluSnippetManagerBundle\EventListener\ConfiguredSnippetTypesProviderInterface;
 use PERSPEQTIVE\SuluSnippetManagerBundle\Security\PermissionTypes;
 use Sulu\Component\Security\Authorization\SecurityCheckerInterface;
 use Sulu\Component\Security\Authorization\SecurityCondition;
@@ -13,6 +14,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 use function array_merge;
+use function in_array;
 use function is_array;
 
 class SnippetAreaNormalizer implements NormalizerInterface, NormalizerAwareInterface
@@ -21,6 +23,7 @@ class SnippetAreaNormalizer implements NormalizerInterface, NormalizerAwareInter
 
     public function __construct(
         private readonly SecurityCheckerInterface $securityChecker,
+        private readonly ConfiguredSnippetTypesProviderInterface $configuredSnippetTypesProvider,
     ) {
     }
 
@@ -73,11 +76,21 @@ class SnippetAreaNormalizer implements NormalizerInterface, NormalizerAwareInter
             return $object;
         }
 
+        $configuredTypes = $this->configuredSnippetTypesProvider->getConfiguredSnippetTypes();
+
         /** @var array{_embedded: array{snippet_areas: array<int, array{templateKey: string}>}} $object */
         $newAreas = [];
         /** @var array<string, string> $area */
         foreach ($object['_embedded']['snippet_areas'] as $area) {
             $templateKey = $area['templateKey'];
+
+            // Areas that are not managed by this bundle have no snippet_manager permission
+            // context, so the permission check must not remove them.
+            if (in_array($templateKey, $configuredTypes, true) === false) {
+                $newAreas[] = $area;
+                continue;
+            }
+
             if ($this->securityChecker->hasPermission(
                 new SecurityCondition('snippet_manager.' . $templateKey . '_' . PermissionTypes::CONTEXT_DEFAULT_SNIPPETS),
                 PermissionTypes::EDIT,

--- a/src/Serializer/SnippetAreaNormalizer.php
+++ b/src/Serializer/SnippetAreaNormalizer.php
@@ -84,9 +84,7 @@ class SnippetAreaNormalizer implements NormalizerInterface, NormalizerAwareInter
         foreach ($object['_embedded']['snippet_areas'] as $area) {
             $templateKey = $area['templateKey'];
 
-            // Areas that are not managed by this bundle have no snippet_manager permission
-            // context, so the permission check must not remove them.
-            if (in_array($templateKey, $configuredTypes, true) === false) {
+            if ($this->isManaged($templateKey, $configuredTypes) === false) {
                 $newAreas[] = $area;
                 continue;
             }
@@ -101,5 +99,16 @@ class SnippetAreaNormalizer implements NormalizerInterface, NormalizerAwareInter
         $object['_embedded']['snippet_areas'] = $newAreas;
 
         return $object;
+    }
+
+    /**
+     * Only areas managed by this bundle have a snippet_manager permission context
+     * and may be filtered by the permission check.
+     *
+     * @param string[] $configuredTypes
+     */
+    private function isManaged(string $templateKey, array $configuredTypes): bool
+    {
+        return in_array($templateKey, $configuredTypes, true);
     }
 }

--- a/tests/Unit/Serializer/SnippetAreaNormalizerTest.php
+++ b/tests/Unit/Serializer/SnippetAreaNormalizerTest.php
@@ -6,6 +6,7 @@ namespace PERSPEQTIVE\SuluSnippetManagerBundle\Tests\Unit\Serializer;
 
 use PERSPEQTIVE\SuluSnippetManagerBundle\Security\PermissionTypes;
 use PERSPEQTIVE\SuluSnippetManagerBundle\Serializer\SnippetAreaNormalizer;
+use PERSPEQTIVE\SuluSnippetManagerBundle\Tests\Mocks\MockConfiguredSnippetTypesProvider;
 use PERSPEQTIVE\SuluSnippetManagerBundle\Tests\Mocks\Sulu\MockSecurityChecker;
 use PERSPEQTIVE\SuluSnippetManagerBundle\Tests\Mocks\Symfony\MockNormalizer;
 use PHPUnit\Framework\TestCase;
@@ -13,16 +14,19 @@ use PHPUnit\Framework\TestCase;
 class SnippetAreaNormalizerTest extends TestCase
 {
     private MockSecurityChecker $securityChecker;
+    private MockConfiguredSnippetTypesProvider $configuredSnippetTypesProvider;
     private MockNormalizer $normalizer;
     private SnippetAreaNormalizer $snippetAreaNormalizer;
 
     protected function setUp(): void
     {
         $this->securityChecker = new MockSecurityChecker(['*' => false]);
+        $this->configuredSnippetTypesProvider = new MockConfiguredSnippetTypesProvider(['area1', 'area2']);
         $this->normalizer = new MockNormalizer(['normalized-result']);
 
         $this->snippetAreaNormalizer = new SnippetAreaNormalizer(
             $this->securityChecker,
+            $this->configuredSnippetTypesProvider,
         );
         $this->snippetAreaNormalizer->setNormalizer($this->normalizer);
     }
@@ -93,6 +97,40 @@ class SnippetAreaNormalizerTest extends TestCase
 
         self::assertSame($expectedModifiedData, $this->normalizer->dataToNormalize);
         self::assertSame(['sulu_admin_snippet_list' => true, SnippetAreaNormalizer::class => true], $this->normalizer->context);
+        self::assertSame(['normalized-data'], $result);
+    }
+
+    public function testNormalizeKeepsAreasThatAreNotManagedByTheBundle(): void
+    {
+        $data = [
+            '_embedded' => [
+                'snippet_areas' => [
+                    ['templateKey' => 'area1'],
+                    ['templateKey' => 'unmanaged_area'],
+                ],
+            ],
+        ];
+
+        $context = ['sulu_admin_snippet_list' => true];
+
+        // No permissions at all: managed areas are filtered out, but areas that are
+        // not configured in this bundle have no snippet_manager permission context
+        // and must be kept.
+        $this->securityChecker->hasPermission = ['*' => false];
+
+        $expectedModifiedData = [
+            '_embedded' => [
+                'snippet_areas' => [
+                    ['templateKey' => 'unmanaged_area'],
+                ],
+            ],
+        ];
+
+        $this->normalizer->result = ['normalized-data'];
+
+        $result = $this->snippetAreaNormalizer->normalize($data, null, $context);
+
+        self::assertSame($expectedModifiedData, $this->normalizer->dataToNormalize);
         self::assertSame(['normalized-data'], $result);
     }
 


### PR DESCRIPTION
The SnippetAreaNormalizer filtered ALL snippet areas of the webspace 'Default Snippets' list by the snippet_manager.<type>_default_snippets permission. Snippet types that are not configured under sulu_snippet_manager.navigation have no such permission context, so the check always failed and every unconfigured (standard Sulu) snippet area disappeared from the list.

Align the normalizer with SnippetAreaResponseListener, which already skips unconfigured types via the ConfiguredSnippetTypesProvider: only areas managed by this bundle are subject to the permission check, everything else is passed through untouched.