### PR TITLE
Filter snippet list by templateKeys for Sulu >= 3.0.8

### DIFF
--- a/src/Admin/ConfiguredSnippetAdmin.php
+++ b/src/Admin/ConfiguredSnippetAdmin.php
@@ -103,7 +103,14 @@ class ConfiguredSnippetAdmin extends Admin
                 ->setEditView($this->buildViewName(ViewTypes::EDIT))
                 ->addLocales($this->localizationProvider->getAllLocales())
                 ->enableFiltering()
-                ->addRequestParameters(['types' => $this->snippetType]),
+                // Sulu >= 3.0.8 filters the snippet list by the "templateKeys" query
+                // parameter; older versions use "types". Send both so the list is
+                // filtered on every supported Sulu 3.0 version. AccessControlManager
+                // still reads "types" for permission checks.
+                ->addRequestParameters([
+                    'types' => $this->snippetType,
+                    'templateKeys' => $this->snippetType,
+                ]),
         );
     }
 

--- a/tests/Unit/Admin/ConfiguredSnippetAdminTest.php
+++ b/tests/Unit/Admin/ConfiguredSnippetAdminTest.php
@@ -148,7 +148,7 @@ class ConfiguredSnippetAdminTest extends TestCase
             'addView' => 'sulu_snippet_manager_testsnippet.add',
             'toolbarActions' => ['save', 'delete'],
             'locales' => ['de', 'en'],
-            'requestParameters' => ['types' => 'testsnippet'],
+            'requestParameters' => ['types' => 'testsnippet', 'templateKeys' => 'testsnippet'],
         ], $listView->getView());
 
         $editFormView = $views['sulu_snippet_manager_testsnippet.edit.details'];


### PR DESCRIPTION
Sulu 3.0.8 renamed the snippet list filter query parameter from "types"
to "templateKeys" (SnippetController::cgetAction now reads
`templateKeys` and ignores `types`). The ConfiguredSnippetAdmin list
view still sent only "types", so no filter was applied and every
snippet type (e.g. webspace_settings) appeared in every configured
snippet list.

Send both parameters from the list view so filtering works on all
supported Sulu 3.0 versions; AccessControlManager keeps reading "types"
for permission checks.